### PR TITLE
Add L7 routing demo

### DIFF
--- a/multi-cloud-vm-consul-mesh-gateway/client-aws.tf
+++ b/multi-cloud-vm-consul-mesh-gateway/client-aws.tf
@@ -14,6 +14,15 @@ module "consul_client_security_group" {
     prefix_list_ids  = null
     self             = true
     }, {
+    protocol         = "tcp"
+    from_port        = "80"
+    to_port          = "80"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = null
+    security_groups  = null
+    prefix_list_ids  = null
+    self             = true
+    },{
     protocol         = "-1"
     from_port        = "0"
     to_port          = "0"
@@ -65,6 +74,17 @@ module "aws_consul_client_2" {
   iam_instance_profile   = module.iam_profile_consul_cloud_auto_join.instance_profile_name
 }
 
+module "aws_consul_client_3" {
+  source                 = "git::https://github.com/timarenz/terraform-aws-virtual-machine.git?ref=v0.1.0"
+  environment_name       = local.environment_name
+  owner_name             = local.owner_name
+  name                   = "consul-client-3-${random_string.random.result}"
+  subnet_id              = module.aws.public_subnet_ids[0]
+  ssh_public_key         = local.ssh_public_key
+  vpc_security_group_ids = [module.consul_client_security_group.id]
+  iam_instance_profile   = module.iam_profile_consul_cloud_auto_join.instance_profile_name
+}
+
 module "aws_consul_client_1_config" {
   source                        = "git::https://github.com/timarenz/terraform-ssh-consul.git?ref=v0.1.0"
   host                          = module.aws_consul_client_1.public_ip
@@ -99,6 +119,23 @@ module "aws_consul_client_2_config" {
   enable_central_service_config = true
 }
 
+module "aws_consul_client_3_config" {
+  source                        = "git::https://github.com/timarenz/terraform-ssh-consul.git?ref=v0.1.0"
+  host                          = module.aws_consul_client_3.public_ip
+  username                      = local.aws_username
+  ssh_private_key               = local.ssh_private_key
+  retry_join                    = ["provider=aws tag_key=${local.aws_discovery_tag} tag_value=${local.aws_discovery_value}"]
+  connect                       = true
+  grpc_port                     = 8502
+  agent_type                    = "client"
+  advertise_addr                = module.aws_consul_client_3.private_ip
+  datacenter                    = local.aws_consul_dc_name
+  primary_datacenter            = local.gcp_consul_dc_name
+  consul_version                = local.consul_version
+  enable_local_script_checks    = true
+  enable_central_service_config = true
+}
+
 resource "null_resource" "aws_consul_client_1_meshify" {
   depends_on = [module.aws_consul_client_1_config]
   connection {
@@ -110,20 +147,8 @@ resource "null_resource" "aws_consul_client_1_meshify" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/install-docker.sh",
-      "${path.module}/scripts/mesh-connect-dashboard-service.sh"
-    ]
-  }
-
-  provisioner "remote-exec" {
-    inline = [<<EOF
-sudo docker run -d --network host --name gateway-aws timarenz/envoy-consul:v1.11.1_1.6.1 -mesh-gateway -register \
-  -service "gateway-aws" \
-  -bind-address bind=${module.aws_consul_client_1.private_ip}:8443 \
-  -address ${module.aws_consul_client_1.private_ip}:8443 \
-  -wan-address ${module.aws_consul_client_1.public_ip}:8443 \
-  -admin-bind localhost:19001 \
-  -- -l debug
-EOF
+      "${path.module}/scripts/mesh-connect-dashboard-service.sh",
+      "${path.module}/scripts/mesh-web-admin.sh"
     ]
   }
 }
@@ -139,7 +164,39 @@ resource "null_resource" "aws_consul_client_2_meshify" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/install-docker.sh",
-      "${path.module}/scripts/mesh-connect-counting-service.sh"
+      "${path.module}/scripts/mesh-connect-counting-service.sh",
+      "${path.module}/scripts/mesh-web-login.sh"
+    ]
+  }
+}
+
+resource "null_resource" "aws_consul_client_3_meshify" {
+  depends_on = [module.aws_consul_client_3_config]
+  connection {
+    host        = module.aws_consul_client_3.public_ip
+    user        = local.aws_username
+    private_key = local.ssh_private_key
+  }
+
+  provisioner "remote-exec" {
+    scripts = [
+      "${path.module}/scripts/install-docker.sh",
+      "${path.module}/scripts/mesh-web-L7-routing.sh",
+      "${path.module}/scripts/mesh-web.sh",
+      "${path.module}/scripts/mesh-web-ingress-haproxy.sh"
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [<<EOF
+sudo docker run -d --network host --name gateway-aws timarenz/envoy-consul:v1.11.1_1.6.1 -mesh-gateway -register \
+  -service "gateway-aws" \
+  -bind-address bind=${module.aws_consul_client_3.private_ip}:8443 \
+  -address ${module.aws_consul_client_3.private_ip}:8443 \
+  -wan-address ${module.aws_consul_client_3.public_ip}:8443 \
+  -admin-bind localhost:19003 \
+  -- -l debug
+EOF
     ]
   }
 }

--- a/multi-cloud-vm-consul-mesh-gateway/client-gcp.tf
+++ b/multi-cloud-vm-consul-mesh-gateway/client-gcp.tf
@@ -6,7 +6,7 @@ module "consul_client_firewall" {
   network          = module.gcp.network
   allow_rules = [{
     protocol = "tcp"
-    ports    = ["9002", "8443"]
+    ports    = ["9002", "8443", "80"]
   }]
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["consul-client"]
@@ -38,6 +38,26 @@ module "gcp_consul_client_2" {
   environment_name = local.environment_name
   owner_name       = local.owner_name
   name             = "consul-client-2-${random_string.random.result}"
+  subnet           = module.gcp.subnets[0]
+  username         = local.gcp_username
+  ssh_public_key   = local.ssh_public_key
+  network_tags     = ["consul-client"]
+  access_scopes = [
+    "https://www.googleapis.com/auth/devstorage.read_only",
+    "https://www.googleapis.com/auth/logging.write",
+    "https://www.googleapis.com/auth/monitoring.write",
+    "https://www.googleapis.com/auth/service.management.readonly",
+    "https://www.googleapis.com/auth/servicecontrol",
+    "https://www.googleapis.com/auth/compute.readonly"
+  ]
+}
+
+module "gcp_consul_client_3" {
+  source           = "git::https://github.com/timarenz/terraform-google-virtual-machine.git?ref=v0.1.0"
+  project          = local.gcp_project
+  environment_name = local.environment_name
+  owner_name       = local.owner_name
+  name             = "consul-client-3-${random_string.random.result}"
   subnet           = module.gcp.subnets[0]
   username         = local.gcp_username
   ssh_public_key   = local.ssh_public_key
@@ -86,6 +106,23 @@ module "gcp_consul_client_2_config" {
   enable_central_service_config = true
 }
 
+module "gcp_consul_client_3_config" {
+  source                        = "git::https://github.com/timarenz/terraform-ssh-consul.git?ref=v0.1.0"
+  host                          = module.gcp_consul_client_3.public_ip
+  username                      = local.gcp_username
+  ssh_private_key               = local.ssh_private_key
+  retry_join                    = ["provider=gce project_name=${local.gcp_project} tag_value=${local.gcp_discovery_tag}"]
+  connect                       = true
+  grpc_port                     = 8502
+  agent_type                    = "client"
+  advertise_addr                = module.gcp_consul_client_3.private_ip
+  datacenter                    = local.gcp_consul_dc_name
+  primary_datacenter            = local.gcp_consul_dc_name
+  consul_version                = local.consul_version
+  enable_local_script_checks    = true
+  enable_central_service_config = true
+}
+
 resource "null_resource" "gcp_consul_client_1_meshify" {
   depends_on = [module.gcp_consul_client_1_config]
   connection {
@@ -97,20 +134,8 @@ resource "null_resource" "gcp_consul_client_1_meshify" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/install-docker.sh",
-      "${path.module}/scripts/mesh-connect-dashboard-service.sh"
-    ]
-  }
-
-  provisioner "remote-exec" {
-    inline = [<<EOF
-sudo docker run -d --network host --name gateway-gcp timarenz/envoy-consul:v1.11.1_1.6.1 -mesh-gateway -register \
-  -service "gateway-gcp" \
-  -bind-address bind=${module.gcp_consul_client_1.private_ip}:8443 \
-  -address ${module.gcp_consul_client_1.private_ip}:8443 \
-  -wan-address ${module.gcp_consul_client_1.public_ip}:8443 \
-  -admin-bind localhost:19001 \
-  -- -l debug
-EOF
+      "${path.module}/scripts/mesh-connect-dashboard-service.sh",
+      "${path.module}/scripts/mesh-web-admin.sh"
     ]
   }
 }
@@ -126,7 +151,39 @@ resource "null_resource" "gcp_consul_client_2_meshify" {
   provisioner "remote-exec" {
     scripts = [
       "${path.module}/scripts/install-docker.sh",
-      "${path.module}/scripts/mesh-connect-counting-service.sh"
+      "${path.module}/scripts/mesh-connect-counting-service.sh",
+      "${path.module}/scripts/mesh-web-login.sh"
+    ]
+  }
+}
+
+resource "null_resource" "gcp_consul_client_3_meshify" {
+  depends_on = [module.gcp_consul_client_3_config]
+  connection {
+    host        = module.gcp_consul_client_3.public_ip
+    user        = local.gcp_username
+    private_key = local.ssh_private_key
+  }
+
+  provisioner "remote-exec" {
+    scripts = [
+      "${path.module}/scripts/install-docker.sh",
+      "${path.module}/scripts/mesh-web-L7-routing.sh",
+      "${path.module}/scripts/mesh-web.sh",
+      "${path.module}/scripts/mesh-web-ingress-haproxy.sh"
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [<<EOF
+sudo docker run -d --network host --name gateway-gcp timarenz/envoy-consul:v1.11.1_1.6.1 -mesh-gateway -register \
+  -service "gateway-gcp" \
+  -bind-address bind=${module.gcp_consul_client_3.private_ip}:8443 \
+  -address ${module.gcp_consul_client_3.private_ip}:8443 \
+  -wan-address ${module.gcp_consul_client_3.public_ip}:8443 \
+  -admin-bind localhost:19003 \
+  -- -l debug
+EOF
     ]
   }
 }

--- a/multi-cloud-vm-consul-mesh-gateway/outputs.tf
+++ b/multi-cloud-vm-consul-mesh-gateway/outputs.tf
@@ -30,12 +30,20 @@ output "aws_consul_client_2_public_ip" {
   value = module.aws_consul_client_2.public_ip
 }
 
+output "aws_consul_client_3_public_ip" {
+  value = module.aws_consul_client_3.public_ip
+}
+
 output "gcp_consul_client_1_public_ip" {
   value = module.gcp_consul_client_1.public_ip
 }
 
 output "gcp_consul_client_2_public_ip" {
   value = module.gcp_consul_client_2.public_ip
+}
+
+output "gcp_consul_client_3_public_ip" {
+  value = module.gcp_consul_client_3.public_ip
 }
 
 output "consul_ui_gcp" {
@@ -52,4 +60,28 @@ output "counting_dashboard_gcp" {
 
 output "counting_dashboard_aws" {
   value = "http://${module.aws_consul_client_1.public_ip}:9002"
+}
+
+output "gcp_L7_route_default" {
+  value = "http://${module.gcp_consul_client_3.public_ip}"
+}
+
+output "gcp_L7_route_admin" {
+  value = "http://${module.gcp_consul_client_3.public_ip}/admin"
+}
+
+output "gcp_L7_route_login" {
+  value = "http://${module.gcp_consul_client_3.public_ip}/login"
+}
+
+output "aws_L7_route_default" {
+  value = "http://${module.aws_consul_client_3.public_ip}"
+}
+
+output "aws_L7_route_admin" {
+  value = "http://${module.aws_consul_client_3.public_ip}/admin"
+}
+
+output "aws_L7_route_login" {
+  value = "http://${module.aws_consul_client_3.public_ip}/login"
 }

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-connect-counting-service.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-connect-counting-service.sh
@@ -25,11 +25,9 @@ sudo docker run -d --network host --name counting-proxy timarenz/envoy-consul:v1
 #consul connect proxy -sidecar-for counting -log-level debug
 
 consul config write -<<EOF
-{
-  "kind": "service-defaults",
-  "name": "counting",
-  "protocol": "http"
-}
+kind = "service-defaults"
+name = "counting"
+protocol = "http"
 EOF
 
 consul config write -<<EOF

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-L7-routing.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-L7-routing.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+consul config write -<<EOF
+{
+  "kind": "service-defaults",
+  "name": "web",
+  "protocol": "http"
+}
+EOF
+
+consul config write -<<EOF
+{
+  "kind": "service-defaults",
+  "name": "web-admin",
+  "protocol": "http"
+}
+EOF
+
+consul config write -<<EOF
+{
+  "kind": "service-defaults",
+  "name": "web-login",
+  "protocol": "http"
+}
+EOF
+
+consul config write -<<EOF
+kind = "service-router"
+name = "web"
+routes = [
+  {
+    match {
+      http {
+        path_prefix = "/login"
+      }
+    }
+
+    destination {
+      service = "web-login",
+      prefix_rewrite = "/"
+    }
+  },
+  {
+    match {
+      http {
+        path_prefix = "/admin"
+      }
+    }
+
+    destination {
+      service = "web-admin",
+      prefix_rewrite = "/"
+    }
+  }
+]
+EOF
+
+consul config write -<<EOF
+kind            = "service-resolver"
+name            = "web-login"
+connect_timeout = "15s"
+failover = {
+  "*" = {
+    datacenters = ["dc-aws", "dc-gcp"]
+  }
+}
+EOF
+
+consul config write -<<EOF
+kind            = "service-resolver"
+name            = "web-admin"
+connect_timeout = "15s"
+failover = {
+  "*" = {
+    datacenters = ["dc-aws", "dc-gcp"]
+  }
+}
+EOF
+
+consul config write -<<EOF
+kind            = "service-resolver"
+name            = "web"
+connect_timeout = "15s"
+failover = {
+  "*" = {
+    datacenters = ["dc-aws", "dc-gcp"]
+  }
+}
+EOF
+

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-admin.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-admin.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+sudo mkdir /tmp/web-admin/
+sudo tee /tmp/web-admin/index.html <<EOF
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to /ADMIN API path!</title>
+    </head>
+    <body>
+    <h1>Welcome to /ADMIN API path!</h1>
+    <h1>Located on host $(hostname)</h1>
+    <p>If you see this page, you were redirected by a Consul Service Mesh L7 service-router.</p>
+    </body>
+    </html>
+EOF
+
+sudo docker stop web-admin
+sudo docker rm web-admin
+sudo docker run -d -p 88:80 -v /tmp/web-admin:/usr/share/nginx/html --hostname ${HOSTNAME} --name web-admin nginx
+
+sudo tee /etc/consul.d/web-admin.json <<EOF
+{
+  "service": {
+    "name": "web-admin",
+    "port": 88,
+    "check": {
+      "args": [
+        "curl",
+        "localhost:88"
+      ],
+      "interval": "5s"
+    },
+    "connect": {
+      "sidecar_service": {}
+    }
+  }
+}
+EOF
+sudo consul reload
+
+sudo docker stop web-admin-proxy
+sudo docker rm web-admin-proxy
+sudo docker run -d --network host --name web-admin-proxy timarenz/envoy-consul:v1.11.1_1.6.1 -sidecar-for web-admin -admin-bind localhost:19011 -- -l debug
+

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-ingress-haproxy.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-ingress-haproxy.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+sudo mkdir /tmp/ingress/
+sudo tee /tmp/ingress/haproxy.cfg <<EOF
+frontend ingress
+    bind *:80
+    mode http
+    default_backend connect-sidecar
+backend connect-sidecar
+    mode http
+    balance roundrobin
+    server sidecar 127.0.0.1:90 check
+EOF
+
+sudo docker stop ingress
+sudo docker rm ingress
+sudo docker run -d --network host -v /tmp/ingress:/usr/local/etc/haproxy:ro --hostname ${HOSTNAME} --name ingress haproxy
+
+sudo tee /etc/consul.d/ingress.json <<EOF
+{
+  "service": {
+    "name": "ingress",
+    "port": 80,
+    "check": {
+      "args": [
+        "curl",
+        "localhost:80"
+      ],
+      "interval": "5s"
+    },
+    "connect": {
+      "sidecar_service": {"proxy": {
+          "upstreams": [
+            {
+              "destination_name": "web",
+              "local_bind_port": 90
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+EOF
+sudo consul reload
+
+sudo docker stop ingress-proxy
+sudo docker rm ingress-proxy
+sudo docker run -d --network host --name ingress-proxy timarenz/envoy-consul:v1.11.1_1.6.1 -sidecar-for ingress -admin-bind localhost:19013 -- -l debug
+

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-login.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web-login.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+sudo mkdir /tmp/web-login/
+sudo tee /tmp/web-login/index.html <<EOF
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to /LOGIN API path!</title>
+    </head>
+    <body>
+    <h1>Welcome to /LOGIN API path!</h1>
+    <h1>Located on host $(hostname)</h1>
+    <p>If you see this page, you were redirected by a Consul Service Mesh L7 service-router.</p>
+    </body>
+    </html>
+EOF
+
+sudo docker stop web-login
+sudo docker rm web-login
+sudo docker run -d -p 89:80 -v /tmp/web-login:/usr/share/nginx/html --hostname ${HOSTNAME} --name web-login nginx
+
+sudo tee /etc/consul.d/web-login.json <<EOF
+{
+  "service": {
+    "name": "web-login",
+    "port": 89,
+    "check": {
+      "args": [
+        "curl",
+        "localhost:89"
+      ],
+      "interval": "5s"
+    },
+    "connect": {
+      "sidecar_service": {}
+    }
+  }
+}
+EOF
+sudo consul reload
+
+sudo docker stop web-login-proxy
+sudo docker rm web-login-proxy
+sudo docker run -d --network host --name web-login-proxy timarenz/envoy-consul:v1.11.1_1.6.1 -sidecar-for web-login -admin-bind localhost:19012 -- -l debug

--- a/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web.sh
+++ b/multi-cloud-vm-consul-mesh-gateway/scripts/mesh-web.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+sudo mkdir /tmp/web/
+sudo tee /tmp/web/index.html <<EOF
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to DEFAULT API path!</title>
+    </head>
+    <body>
+    <h1>Welcome to DEFAULT API path!</h1>
+    <h1>Located on host $(hostname)</h1>
+    <p>If you see this page, you were NOT redirected by a Consul Service Mesh L7 service-router and hitting the default service endpoint.</p>
+    </body>
+    </html>
+EOF
+
+sudo docker stop web
+sudo docker rm web
+sudo docker run -d -p 87:80 -v /tmp/web:/usr/share/nginx/html --hostname ${HOSTNAME} --name web nginx
+
+sudo tee /etc/consul.d/web.json <<EOF
+{
+  "service": {
+    "name": "web",
+    "port": 87,
+    "check": {
+      "args": [
+        "curl",
+        "localhost:87"
+      ],
+      "interval": "5s"
+    },
+    "connect": {
+      "sidecar_service": {}
+    }
+  }
+}
+EOF
+sudo consul reload
+
+sudo docker stop web-proxy
+sudo docker rm web-proxy
+sudo docker run -d --network host --name web-proxy timarenz/envoy-consul:v1.11.1_1.6.1 -sidecar-for web -admin-bind localhost:19010 -- -l debug
+


### PR DESCRIPTION
This PR adds a simple L7 service-router demo to the environment.
The service-router is matching on "catch all", /admin and /login HTTP paths and redirects to backend services accordingly. DC failover for those services is implemented with service-resolvers.
These "web" services are made available by an Ingress HAProxy component exposed on Client-3 within each DC.

Additionally, a 3rd Consul client is introduced in each DC for load distribution.

TF output adjusted accordingly.

Cleanup of "counting service" default config to be HCL only.